### PR TITLE
Repositioning hacks

### DIFF
--- a/addon/components/deluge-dropdown/component.js
+++ b/addon/components/deluge-dropdown/component.js
@@ -35,7 +35,6 @@ export default Ember.Component.extend(Registry, Registerable, KeyBindings, {
     },
 
     selectNext() {
-      console.log('down');
       let menu;
       if (menu = this.get('menu')) {
         menu.send('selectNext');
@@ -43,7 +42,6 @@ export default Ember.Component.extend(Registry, Registerable, KeyBindings, {
     },
 
     selectPrevious() {
-      console.log('up');
       let menu;
       if (menu = this.get('menu')) {
         menu.send('selectPrevious');

--- a/addon/components/deluge-menu-button/component.js
+++ b/addon/components/deluge-menu-button/component.js
@@ -128,7 +128,7 @@ export default Ember.Component.extend(ControlState, Registerable, Registry, KeyB
   ],
 
   ariaRole: 'group',
-  hasPopUp: computed.oneWay('hasDropdown'),
+  hasPopUp: true,
 
   keyBindings: {
     esc: 'close',

--- a/addon/components/deluge-menu-button/component.js
+++ b/addon/components/deluge-menu-button/component.js
@@ -174,14 +174,14 @@ export default Ember.Component.extend(ControlState, Registerable, Registry, KeyB
    *
    * @return {PositionRect}
    */
-  _positionRect: computed('element', 'positionTarget', function() {
+  _positionRect: computed('positionTarget', function() {
     const positionTarget = this.get('positionTarget');
     if (isPresent(positionTarget)) {
       return this.element.querySelector(positionTarget).getBoundingClientRect();
     }else{
       return this.element.getBoundingClientRect();
     }
-  }),
+  }).volatile(),
 
   /**
    * The horizontal offset value used to position the dropdown.
@@ -220,8 +220,6 @@ export default Ember.Component.extend(ControlState, Registerable, Registry, KeyB
   positionStyles: Ember.computed(function() {
     const { horizontalAlign, verticalAlign } = this.getProperties('horizontalAlign', 'verticalAlign');
     const { _horizontalAlignTargetValue: horizontal, _verticalAlignTargetValue: vertical } = this.getProperties('_horizontalAlignTargetValue', '_verticalAlignTargetValue');
-    // let styleObject = {
-    // };
 
     let styleObject = {
       position: 'absolute',

--- a/addon/components/deluge-menu-button/component.js
+++ b/addon/components/deluge-menu-button/component.js
@@ -97,7 +97,12 @@ export default Ember.Component.extend(ControlState, Registerable, Registry, KeyB
    *
    * @type {Number}
    */
-  verticalOffset: 0,
+  verticalOffset: computed('_positionRect', {
+    get() {
+      const { height } = this.get('_positionRect');
+      return height;
+    }
+  }),
 
   /**
    * Set to true to disable automatically closing the dropdown after

--- a/addon/components/deluge-menu-button/template.hbs
+++ b/addon/components/deluge-menu-button/template.hbs
@@ -8,12 +8,12 @@
 
 {{#if isOpen}}
   {{#ember-wormhole to=destinationElementId renderInPlace=renderInPlace}}
-    {{#ember-tether
+    {{!-- {{#ember-tether
       target=dropdownTarget
       targetAttachment="bottom left"
       attachment="top left"
-    }}
+    }} --}}
       <div style={{computedPositionStyle}} class="deluge-menu-button-content">{{yield}}</div>
-    {{/ember-tether}}
+    {{!-- {{/ember-tether}} --}}
   {{/ember-wormhole}}
 {{/if}}

--- a/addon/components/deluge-menu/component.js
+++ b/addon/components/deluge-menu/component.js
@@ -6,7 +6,11 @@ import MenuBehaviour from '../../mixins/menu-behaviour';
 import ControlState from '../../mixins/control-state';
 import KeyBindings from '../../mixins/key-bindings';
 
-const { computed, isEmpty } = Ember;
+const {
+  computed,
+  isEmpty,
+  run: { next },
+} = Ember;
 
 function afterRender() {
   Ember.run.schedule('afterRender', ...arguments);
@@ -147,7 +151,9 @@ export default Ember.Component.extend(KeyBindings, ControlState, MenuBehaviour, 
         }
       }
 
-      this.sendAction('action', this.get('selectedItemValues'));
+      next(this, function() {
+        this.sendAction('action', this.get('selectedItemValues'));
+      });
     },
 
     registerItem(itemComponent) {

--- a/addon/mixins/registerable.js
+++ b/addon/mixins/registerable.js
@@ -24,8 +24,6 @@ export default Ember.Mixin.create({
       let actionAcceptor;
       if (actionAcceptor = this.get('actionAcceptor')) {
         this.set('targetObject', actionAcceptor);
-
-        console.log(`setting action acceptor of ${this.element.tagName} to ${actionAcceptor.element.tagName}`);
         // Set our default action to be whatever the parent accepts
         let childActionName;
         if (childActionName = actionAcceptor.get('childActionName')) {

--- a/index.js
+++ b/index.js
@@ -4,6 +4,10 @@
 module.exports = {
   name: 'deluge',
 
+  isDevelopingAddon: function() {
+    return true;
+  },
+
   included: function(app) {
     this._super.included(app);
     var emberTetherAddon = this.addons.filter(function(addon) {


### PR DESCRIPTION
This PR removes the use of Tether, because it has funky side-effects on flex-box layouts. It's also slow and requires recomputing. We should however borrow some ideas from it for absolute positioning in the future.
