### PR TITLE
Remove quotes from @extends

### DIFF
--- a/addon/styles/components/deluge-item.scss
+++ b/addon/styles/components/deluge-item.scss
@@ -14,7 +14,7 @@ $deluge-item-body-three-line-min-height: 88px !default;
   font-weight: 400;
   line-height: 24px;
 
-  @extend ".deluge-font-subhead";
+  @extend .deluge-font-subhead;
 
   &.is-selected {
     font-weight: bold;
@@ -69,7 +69,7 @@ $deluge-item-body-three-line-min-height: 88px !default;
   [secondary] {
     line-height: 20px;
     color: $secondary-text-color;
-    @extend ".deluge-font-body1";
+    @extend .deluge-font-body1;
     // @apply(--paper-item-body-secondary);
   }
 }

--- a/addon/styles/typography.scss
+++ b/addon/styles/typography.scss
@@ -21,11 +21,11 @@
 /* Material Font Styles */
 
 .deluge-font-display4 {
-  @extend ".deluge-font-common-base";
+  @extend .deluge-font-common-base;
   font-family: 'Roboto', 'Noto', sans-serif;
   -webkit-font-smoothing: antialiased;
 
-  @extend ".deluge-font-common-nowrap";
+  @extend .deluge-font-common-nowrap;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -37,11 +37,11 @@
 }
 
 .deluge-font-display3 {
-  @extend ".deluge-font-common-base";
+  @extend .deluge-font-common-base;
   font-family: 'Roboto', 'Noto', sans-serif;
   -webkit-font-smoothing: antialiased;
 
-  @extend ".deluge-font-common-nowrap";
+  @extend .deluge-font-common-nowrap;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -53,7 +53,7 @@
 }
 
 .deluge-font-display2 {
-  @extend ".deluge-font-common-base";
+  @extend .deluge-font-common-base;
   font-family: 'Roboto', 'Noto', sans-serif;
   -webkit-font-smoothing: antialiased;
 
@@ -65,7 +65,7 @@
 }
 
 .deluge-font-display1 {
-  @extend ".deluge-font-common-base";
+  @extend .deluge-font-common-base;
   font-family: 'Roboto', 'Noto', sans-serif;
   -webkit-font-smoothing: antialiased;
 
@@ -77,7 +77,7 @@
 }
 
 .deluge-font-headline {
-  @extend ".deluge-font-common-base";
+  @extend .deluge-font-common-base;
   font-family: 'Roboto', 'Noto', sans-serif;
   -webkit-font-smoothing: antialiased;
 
@@ -89,11 +89,11 @@
 }
 
 .deluge-font-title {
-  @extend ".deluge-font-common-base";
+  @extend .deluge-font-common-base;
   font-family: 'Roboto', 'Noto', sans-serif;
   -webkit-font-smoothing: antialiased;
 
-  @extend ".deluge-font-common-nowrap";
+  @extend .deluge-font-common-nowrap;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -104,7 +104,7 @@
 }
 
 .deluge-font-subhead {
-  @extend ".deluge-font-common-base";
+  @extend .deluge-font-common-base;
   font-family: 'Roboto', 'Noto', sans-serif;
   -webkit-font-smoothing: antialiased;
 
@@ -115,7 +115,7 @@
 }
 
 .deluge-font-body2 {
-  @extend ".deluge-font-common-base";
+  @extend .deluge-font-common-base;
   font-family: 'Roboto', 'Noto', sans-serif;
   -webkit-font-smoothing: antialiased;
 
@@ -125,7 +125,7 @@
 }
 
 .deluge-font-body1 {
-  @extend ".deluge-font-common-base";
+  @extend .deluge-font-common-base;
   font-family: 'Roboto', 'Noto', sans-serif;
   -webkit-font-smoothing: antialiased;
 
@@ -135,10 +135,10 @@
 }
 
 .deluge-font-caption {
-  @extend ".deluge-font-common-base";
+  @extend .deluge-font-common-base;
   font-family: 'Roboto', 'Noto', sans-serif;
   -webkit-font-smoothing: antialiased;
-  @extend ".deluge-font-common-nowrap";
+  @extend .deluge-font-common-nowrap;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -150,11 +150,11 @@
 }
 
 .deluge-font-menu {
-  @extend ".deluge-font-common-base";
+  @extend .deluge-font-common-base;
   font-family: 'Roboto', 'Noto', sans-serif;
   -webkit-font-smoothing: antialiased;
 
-  @extend ".deluge-font-common-nowrap";
+  @extend .deluge-font-common-nowrap;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -165,11 +165,11 @@
 }
 
 .deluge-font-button {
-  @extend ".deluge-font-common-base";
+  @extend .deluge-font-common-base;
   font-family: 'Roboto', 'Noto', sans-serif;
   -webkit-font-smoothing: antialiased;
 
-  @extend ".deluge-font-common-nowrap";
+  @extend .deluge-font-common-nowrap;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -182,7 +182,7 @@
 }
 
 .deluge-font-code2 {
-  @extend ".deluge-font-common-code";
+  @extend .deluge-font-common-code;
   font-family: 'Roboto Mono', 'Consolas', 'Menlo', monospace;
   -webkit-font-smoothing: antialiased;
 
@@ -192,7 +192,7 @@
 }
 
 .deluge-font-code1 {
-  @extend ".deluge-font-common-code";
+  @extend .deluge-font-common-code;
   font-family: 'Roboto Mono', 'Consolas', 'Menlo', monospace;
   -webkit-font-smoothing: antialiased;
 


### PR DESCRIPTION
These quotes were causing a compile error.

```
remote: File: /tmp/build_12ac1dd2069443f0bc0592c06b2b24c2/tmp/sass_compiler-input_base_path-6QFAGVDn.tmp/0/typography.scss (24)
remote: ".deluge-font-display4" failed to @extend "".deluge-font-common-base"".
remote: The selector "".deluge-font-common-base"" was not found.
remote: Use "@extend ".deluge-font-common-base" !optional" if the extend should be able to fail.
remote: Error: ".deluge-font-display4" failed to @extend "".deluge-font-common-base"".
remote: The selector "".deluge-font-common-base"" was not found.
remote: Use "@extend ".deluge-font-common-base" !optional" if the extend should be able to fail.
remote:     at options.error (/app/tmp/cache/node_modules/deluge/node_modules/ember-cli-sass/node_modules/broccoli-sass-source-maps/node_modules/node-sass/lib/index.js:272:32)
```
